### PR TITLE
IGListCollectionViewLayout: fix warning.

### DIFF
--- a/Source/IGListKit/IGListCollectionViewLayout.h
+++ b/Source/IGListKit/IGListCollectionViewLayout.h
@@ -10,7 +10,7 @@
 #import <IGListDiffKit/IGListExperiments.h>
 #import <IGListDiffKit/IGListMacros.h>
 
-#import "IGListCollectionViewLayoutCompatible.h"
+#import <IGListKit/IGListCollectionViewLayoutCompatible.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Fix import warning in Xcode 16.

The motivation for fixing it now is that the last PR here with fixes was merged to a side branch, and we ended up not using it. To avoid such confusions in the future, the side branch is now the main branch of this fork, and we will move to it. Before doing it, we need to ensure this compiles in Xcode 16, and this commit fixes it.
